### PR TITLE
Fix two errors impacting program functionality

### DIFF
--- a/rvv-rollback.py
+++ b/rvv-rollback.py
@@ -122,6 +122,8 @@ def replace_instruction(line, linenum, verbosity):
         newline += "\tsd     t1, 8(sp)\n"
         newline += "\tcsrr     t0, vl\n"
         newline += "\tcsrr     t1, vtype\n"
+        temp_vset = ""
+        temp_vinstr = ""
         match instruction[0]:
             case 'vl1r.v' | 'vl1re8.v' | 'vl1re16.v' | 'vl1re32' | 'vl1re64':
                 temp_vset ="\tvsetvli  x0, x0, e32, m1\n"

--- a/rvv-rollback.py
+++ b/rvv-rollback.py
@@ -112,10 +112,10 @@ def replace_instruction(line, linenum, verbosity):
         instruction = re.split(r"[, \t]+", line.lstrip())
         rd = instruction[1]
         rs = instruction[2]
-        if (instruction[3]):
-            vm = instruction[3]
-        else:
+        if (len(instruction) <= 3):
             vm = ""
+        elif (instruction[3]):
+            vm = instruction[3]
         newline = "# Replacing Line: {LINENUM} - {LINE}".format(
                     LINENUM=linenum, LINE=line)
         newline += "\tsd     t0, 0(sp)\n"


### PR DESCRIPTION
While testing this program `rvv-rollback.py`, I encountered two errors: an IndexError and an UnboundLocalError. I attempted to address these issues using the simplest possible modifications. Below, I've provided details about the Python version I used and the specific error messages that occurred during the execution of these two scripts. 

The first error occurs when a replacement is needed, and the 1p0 assembly instruction has only 3 elements, thus triggering an index error. The second error occurs because no initialization is done. 

1. IndexError:
```bash
> ./py-rollback.sh
input file = rvv_saxpy_1p0.s  |  output file = rvv_saxpy_0p7.s

['vl2re32.v', 'v10', '(a4)\n']
Traceback (most recent call last):
  File "/home/ty/testspace/rvvRollBack/scripts/rvv-rollback.py", line 381, in <module>
    main(args)
  File "/home/ty/testspace/rvvRollBack/scripts/rvv-rollback.py", line 343, in main
    newline = replace_instruction(line, linenum, args.verbose)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ty/testspace/rvvRollBack/scripts/rvv-rollback.py", line 119, in replace_instruction
    elif (instruction[3]):
          ~~~~~~~~~~~^^^
IndexError: list index out of range
```

2. UnboundLocalError:
```bash
> ./py-rollback.sh
input file = rvv_saxpy_1p0.s  |  output file = rvv_saxpy_0p7.s

['vl2re32.v', 'v10', '(a4)\n']
Traceback (most recent call last):
  File "/home/ty/testspace/rvvRollBack/scripts/rvv-rollback.py", line 381, in <module>
    main(args)
  File "/home/ty/testspace/rvvRollBack/scripts/rvv-rollback.py", line 343, in main
    newline = replace_instruction(line, linenum, args.verbose)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ty/testspace/rvvRollBack/scripts/rvv-rollback.py", line 178, in replace_instruction
    newline += temp_vset
    ^^^^^^^
UnboundLocalError: cannot access local variable 'temp_vset' where it is not associated with a value
> ./py-rollback.sh
input file = rvv_saxpy_1p0.s  |  output file = rvv_saxpy_0p7.s

['vl2re32.v', 'v10', '(a4)\n']
Traceback (most recent call last):
  File "/home/ty/testspace/rvvRollBack/scripts/rvv-rollback.py", line 382, in <module>
    main(args)
  File "/home/ty/testspace/rvvRollBack/scripts/rvv-rollback.py", line 344, in main
    newline = replace_instruction(line, linenum, args.verbose)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ty/testspace/rvvRollBack/scripts/rvv-rollback.py", line 180, in replace_instruction
    newline += temp_vinstr
    ^^^^^^^
UnboundLocalError: cannot access local variable 'temp_vinstr' where it is not associated with a value
```